### PR TITLE
TypeScript definition fixes

### DIFF
--- a/types/components.d.ts
+++ b/types/components.d.ts
@@ -134,12 +134,12 @@ export declare type BDialogConfig = {
     /**
      * Callback function when the confirm button is clicked
      */
-    onConfirm?: (value: string, dialog: BComponent) => any;
+    confirmCallback?: (value: string, dialog: BComponent) => any;
 
     /**
      * Callback function when the dialog is canceled (cancel button is clicked / pressed escape / clicked outside)
      */
-    onCancel?: () => any;
+    cancelCallback?: () => any;
 
     /**
      * Type (color) of the confirm button (and the icon if <code>hasIcon</code>)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,4 @@
-import _Vue from "vue";
+import type { App } from "vue";
 
 import {
     BuefyConfig,
@@ -28,7 +28,7 @@ export declare type BuefyNamespace = {
 }
 
 declare const _default: {
-    install(Vue: typeof _Vue, config: BuefyConfig): void;
+    install(app: App, config: BuefyConfig): void;
 };
 
 export {


### PR DESCRIPTION
I'm attempting to convert a project using Buefy to Vue3 using this fork, so far very successfully (thanks!). It's also using TypeScript, and I realized those definitions have probably not been touched. Here's a few basic ones, which at least make sure `app.use(Buefy)` isn't an error, and programmatic dialogs don't suggest `onConfirm` / `onCancel` anymore. I want to look at the other definitions for programmatic access later.
