### PR TITLE
table/checkbox bugfix

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -284,7 +284,7 @@
                                     :model-value="isRowChecked(row)"
                                     :type="checkboxType"
                                     :disabled="!isRowCheckable(row)"
-                                    @click.prevent.stop="checkRow(row, index, $event)"
+                                    @input.prevent.stop="checkRow(row, index, $event)"
                                 />
                             </td>
 
@@ -317,7 +317,7 @@
                                     :model-value="isRowChecked(row)"
                                     :type="checkboxType"
                                     :disabled="!isRowCheckable(row)"
-                                    @click.prevent.stop="checkRow(row, index, $event)"
+                                    @input.prevent.stop="checkRow(row, index, $event)"
                                 />
                             </td>
                         </tr>


### PR DESCRIPTION
changed @click event on b-checkbox to @input to get checkbox events working

I noticed that the table "checkable" checkboxes were not emitting their events when checked and saw that the Buefy docs only show an "input" event but the kikumax/buefy table component is using the @click event.  Changing this to @input fixed the table for me.

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

- changing the "@click" event to "@input" on the table's row checkboxes
-
-
