### PR TITLE
Restore onConfirm/onCancel props for programmatically opening a dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Buefy Changelog
 
+## 0.9.21-vue3-2
+
+### Breadking changes
+
+* The `onConfirm`, and `onCancel` props given to functions (`dialog.alert`, `dialog.confirm`, and `dialog.prompt`) that programmatically open a `Dialog` are restored, and these functions now ignore the `confirmCallback`, and `cancelCallback` props. ([#529394d7c77967bc156a386a99a9dda6c78d2780](https://github.com/kikuomax/buefy/commit/529394d7c77967bc156a386a99a9dda6c78d2780))
+* The `onCancel` prop given to `modal.open` is restored, and `modal.open` ignores the `cancelCallback` prop. ([#529394d7c77967bc156a386a99a9dda6c78d2780](https://github.com/kikuomax/buefy/commit/529394d7c77967bc156a386a99a9dda6c78d2780))
+
 ## 0.9.21-vue3-1
 
 ### Breaking changes

--- a/MIGRATION-NOTE.md
+++ b/MIGRATION-NOTE.md
@@ -102,7 +102,11 @@ But they are interpreted as event listeners on Vue 3.
 As a workaround, the callback functions are renamed to `confirmCallback`, and `cancelCallback` respectively.
 See [#185e353a154b661ba2fa423e5066a4cea761250a](https://github.com/kikuomax/buefy/commit/185e353a154b661ba2fa423e5066a4cea761250a).
 
-See also [Vue's migration guide](https://v3.vuejs.org/guide/migration/render-function-api.html#_2-x-syntax-3).
+See also [Vue's migration guide](https://v3-migration.vuejs.org/breaking-changes/render-function-api.html#vnode-props-format).
+
+In the version `v0.9.21-vue3-1`, you had to specify `confirmCallback`, and `cancelCallback` properties instead of `onConfirm`, and `onCancel` respectively when you want to programmatically open a `Dialog`.
+However, since the version `v0.9.21-vue3-2`, `onConfirm`, and `onCancel` are back again, and you have to specify `onConfirm`, and `onCancel` to programmatically open a `Dialog`.
+See [#529394d7c77967bc156a386a99a9dda6c78d2780](https://github.com/kikuomax/buefy/commit/529394d7c77967bc156a386a99a9dda6c78d2780).
 
 ## Emitted events
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ Because not all of Vue 2 features could be reproduced with Vue 3, there are some
 Please refer to [CHANGELOG.md](./CHANGELOG.md) for more details.
 The biggest breaking change is obviously, **this does not work with Vue 2**.
 
+**Properties for programmatically opening a `Dialog` or `Modal` have changed from `v0.9.21-vue3-1` to `v0.9.21-vue-2` (became compatible with the original Buefy).**
+Please refer to [CHANGELOG.md](./CHANGELOG.md#0921-vue3-2) for more details.
+
 ### How to install
 
 To install this fork, please run the following command,
@@ -43,6 +46,9 @@ To install this fork, please run the following command,
 ```sh
 npm install 'https://github.com/kikuomax/buefy.git'
 ```
+
+The latest version is tagged `v0.9.21-vue3-2`.
+
 
 If you need the previous version that is based on Buefy v0.9.7, please run the following command,
 

--- a/docs/pages/components/autocomplete/examples/ExFooter.vue
+++ b/docs/pages/components/autocomplete/examples/ExFooter.vue
@@ -64,7 +64,7 @@
                         value: this.name
                     },
                     confirmText: 'Add',
-                    confirmCallback: (value) => {
+                    onConfirm: (value) => {
                         this.data.push(value)
                         this.$refs.autocomplete.setSelected(value)
                     }

--- a/docs/pages/components/autocomplete/examples/ExHeader.vue
+++ b/docs/pages/components/autocomplete/examples/ExHeader.vue
@@ -79,7 +79,7 @@
                         value: this.name
                     },
                     confirmText: 'Add',
-                    confirmCallback: (value) => {
+                    onConfirm: (value) => {
                         this.data.push(value)
                         this.$refs.autocomplete.setSelected(value)
                     }

--- a/docs/pages/components/dialog/examples/ExConfirmDialog.vue
+++ b/docs/pages/components/dialog/examples/ExConfirmDialog.vue
@@ -28,7 +28,7 @@
             confirm() {
                 this.$buefy.dialog.confirm({
                     message: 'Continue on this task?',
-                    confirmCallback: () => this.$buefy.toast.open('User confirmed')
+                    onConfirm: () => this.$buefy.toast.open('User confirmed')
                 })
             },
             confirmCustom() {
@@ -57,7 +57,7 @@
                     cancelText: 'Disagree',
                     confirmText: 'Agree',
                     type: 'is-success',
-                    confirmCallback: () => this.$buefy.toast.open('User agreed')
+                    onConfirm: () => this.$buefy.toast.open('User agreed')
                 })
             },
             confirmCustomDelete() {
@@ -67,7 +67,7 @@
                     confirmText: 'Delete Account',
                     type: 'is-danger',
                     hasIcon: true,
-                    confirmCallback: () => this.$buefy.toast.open('Account deleted!')
+                    onConfirm: () => this.$buefy.toast.open('Account deleted!')
                 })
             }
         }

--- a/docs/pages/components/dialog/examples/ExPromptDialog.vue
+++ b/docs/pages/components/dialog/examples/ExPromptDialog.vue
@@ -33,7 +33,7 @@ export default {
                     maxlength: 10
                 },
                 trapFocus: true,
-                confirmCallback: (value) => this.$buefy.toast.open(`Your name is: ${value}`)
+                onConfirm: (value) => this.$buefy.toast.open(`Your name is: ${value}`)
             })
         },
         promptNumber() {
@@ -47,7 +47,7 @@ export default {
                     max: 99
                 },
                 trapFocus: true,
-                confirmCallback: (value) => this.$buefy.toast.open(`Your age is: ${value}`)
+                onConfirm: (value) => this.$buefy.toast.open(`Your age is: ${value}`)
             })
         },
         promptNotClosed() {
@@ -61,7 +61,7 @@ export default {
                 confirmText: 'Send',
                 trapFocus: true,
                 closeOnConfirm: false,
-                confirmCallback: (value, {close}) => {
+                onConfirm: (value, {close}) => {
                     this.$buefy.toast.open(`Your message is sending...`)
                     setTimeout(() => {
                         this.$buefy.toast.open(`Success message send!`)

--- a/src/components/dialog/index.js
+++ b/src/components/dialog/index.js
@@ -33,16 +33,30 @@ function open(propsData) {
                     Dialog,
                     {
                         ...propsData,
+                        // intentionally overrides propsData.onConfirm
+                        // to prevent propsData.onConfirm from receiving a "confirm" event
                         onConfirm: (...args) => {
                             if (onConfirm != null) {
                                 onConfirm(...args)
                             }
                         },
+                        // intentionally override propsData.onCancel
+                        // to prevent propsData.onCancel from receiving a "cancel" event
                         onCancel: (...args) => {
                             if (onCancel != null) {
                                 onCancel(...args)
                             }
                             vueInstance.unmount()
+                        },
+                        confirmCallback: (...args) => {
+                            if (propsData.onConfirm != null) {
+                                propsData.onConfirm(...args)
+                            }
+                        },
+                        cancelCallback: (...args) => {
+                            if (propsData.onCancel != null) {
+                                propsData.onCancel(...args)
+                            }
                         }
                     },
                     slot ? { default: () => slot } : undefined

--- a/src/components/modal/index.js
+++ b/src/components/modal/index.js
@@ -55,6 +55,14 @@ const ModalProgrammatic = {
                         ...propsData,
                         onClose: () => {
                             vueInstance.unmount()
+                        },
+                        // intentionally overrides propsData.onCancel
+                        // to prevent propsData.onCancel from receiving a "cancel" event
+                        onCancel: () => {},
+                        cancelCallback: (...args) => {
+                            if (propsData.onCancel != null) {
+                                propsData.onCancel(...args)
+                            }
                         }
                     },
                     slot ? { default: () => slot } : undefined


### PR DESCRIPTION
@ElteHupkes and @kyle-jennings, thanks for your PRs:
- #1
- #4

As @ElteHupkes [commented](https://github.com/kikuomax/buefy/pull/4#issuecomment-1403650776), I intentionally replaced `onConfirm` and `onCancel` props of `Dialog` with `confirmCallback` and `cancelCallback`, because they conflict with event listeners for `@confirm` and `@cancel` on Vue 3.

However, I came up with a workaround to keep my fork better compatible with the original buefy. With this PR merged, you can specify `onConfirm` and `onCancel` to props for programmatically opening a `Dialog` or `Modal` as you do on the original buefy.