### PR TITLE
fixed checkbox emit bug on tables

### DIFF
--- a/src/components/table/Table.vue
+++ b/src/components/table/Table.vue
@@ -284,7 +284,7 @@
                                     :model-value="isRowChecked(row)"
                                     :type="checkboxType"
                                     :disabled="!isRowCheckable(row)"
-                                    @click.prevent.stop="checkRow(row, index, $event)"
+                                    @input.prevent.stop="checkRow(row, index, $event)"
                                 />
                             </td>
 
@@ -317,7 +317,7 @@
                                     :model-value="isRowChecked(row)"
                                     :type="checkboxType"
                                     :disabled="!isRowCheckable(row)"
-                                    @click.prevent.stop="checkRow(row, index, $event)"
+                                    @input.prevent.stop="checkRow(row, index, $event)"
                                 />
                             </td>
                         </tr>


### PR DESCRIPTION
The table "checkRow" method was not firing because the Buefy checkbox component fires an "input" event but this was listening for a "click" event.

