### PR TITLE
Btag bug fix

### DIFF
--- a/src/components/tag/Tag.vue
+++ b/src/components/tag/Tag.vue
@@ -69,8 +69,14 @@
 </template>
 
 <script>
+
+import BTag from '../icon/Icon.vue';
+
 export default {
     name: 'BTag',
+    components: {
+        BTag,
+    },
     props: {
         attached: Boolean,
         closable: Boolean,

--- a/src/components/tag/Tag.vue
+++ b/src/components/tag/Tag.vue
@@ -70,12 +70,12 @@
 
 <script>
 
-import BTag from '../icon/Icon.vue';
+import BIcon from '../icon/Icon.vue';
 
 export default {
     name: 'BTag',
     components: {
-        BTag,
+        BIcon,
     },
     props: {
         attached: Boolean,


### PR DESCRIPTION
BTag components are not importing the BIcon component they use so they throw a warning that a component hasn't been defined/declared or whatever.  This fixes that warning.

<!-- Thank you for helping Buefy! -->

Fixes #
<!-- If this PR fixes GitHub issue 1234, add "Fixes #1234" to the next line. -->

## Proposed Changes

-
-
-
